### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server for TiDB that allows executing SELECT queries through MCP tools.
 
+<a href="https://glama.ai/mcp/servers/@l1806858547/tidb-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@l1806858547/tidb-server/badge" alt="TiDB Server MCP server" />
+</a>
+
 ## Features
 - Execute SELECT queries on TiDB
 - Secure connection via environment variables


### PR DESCRIPTION
This PR adds a badge for the [TiDB MCP Server](https://glama.ai/mcp/servers/@l1806858547/tidb-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@l1806858547/tidb-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@l1806858547/tidb-server/badge" alt="TiDB Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.